### PR TITLE
Adding `$parameters` extra parameter for fetch + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Requires search keyword and accepts type (movie, series or episode) & year
 
 
 ```php
+use aharen\OMDbAPI();
+
+$omdb = new OMDbAPI();
+
 $omdb->search($keyword, $type, $year);
 
 ```
@@ -33,8 +37,6 @@ Example usage
 
 
 ```php
-$omdb = new OMDbAPI();
-
 $omdb->search('spider');
 
 ```
@@ -157,7 +159,6 @@ $omdb->fetch('i', 'tt0338013');
 
 // get details for title 'eternal sunshine'
 $omdb->fetch('t', 'eternal sunshine');
-
 ```
 
 Output for both of the above queires
@@ -192,5 +193,15 @@ stdClass Object
         )
 
 )
-
 ```
+
+### Fetching episodes details
+
+You can also use the `fetch` third parameter to add extra parameters, for instance:
+
+```php
+//                 Dexter (TV show)
+$omdb->fetch('i', 'tt0773262', ['Season' => 1])
+```
+
+This will add the `Season=1` parameter

--- a/src/OMDbAPI.php
+++ b/src/OMDbAPI.php
@@ -81,9 +81,10 @@ class OMDbAPI
      *
      * @param string $field
      * @param string $keyword
+     * @param array $parameters extra parameters
      * @return array
      */
-    public function fetch($field, $keyword)
+    public function fetch($field, $keyword, array $parameters = array())
     {
         if ((!isset($field) && empty($field)) || (!isset($keyword) && empty($keyword))) {
             return $this->output('400', 'Missing required fields');
@@ -97,7 +98,8 @@ class OMDbAPI
             return $this->output('400', 'Invalid IMDB ID provided');
         }
 
-        $api_uri = '?' . $field . '=' . urlencode($keyword);
+        $parameters[$field] = $keyword;
+        $api_uri = '?' . http_build_query($parameters);
         return $this->get($api_uri);
     }
 


### PR DESCRIPTION
First, thanks for your work

This adds an extra parameters in `fetch()`, allowing for instance to retrieve the episodes from a season of a TV show

I also updated the README (fixing typo and adding the missing `use` line in the examples)